### PR TITLE
Fixed examples' accelerometer usage

### DIFF
--- a/examples/readCalibration/readCalibration.ino
+++ b/examples/readCalibration/readCalibration.ino
@@ -50,9 +50,9 @@ void loop()
   for (int i = 0; i < 20; i++)
   {
     sensor.read();
-    ax -= sensor.getAngleX();
-    ay -= sensor.getAngleY();
-    az -= sensor.getAngleZ();
+    ax -= sensor.getAccelX();
+    ay -= sensor.getAccelY();
+    az -= sensor.getAccelZ();
     gx -= sensor.getGyroX();
     gy -= sensor.getGyroY();
     gz -= sensor.getGyroZ();

--- a/examples/test1/test1.ino
+++ b/examples/test1/test1.ino
@@ -43,9 +43,9 @@ void setup()
 void loop()
 {
   sensor.read();
-  int ax = sensor.getAngleX();
-  int ay = sensor.getAngleY();
-  int az = sensor.getAngleZ();
+  int ax = sensor.getAccelX();
+  int ay = sensor.getAccelY();
+  int az = sensor.getAccelZ();
   int gx = sensor.getGyroX();
   int gy = sensor.getGyroY();
   int gz = sensor.getGyroZ();


### PR DESCRIPTION
The examples were using `GetAngle` instead of using `GetAccel`