### PR TITLE
Added orientation arguments to calibrate function

### DIFF
--- a/GY521.cpp
+++ b/GY521.cpp
@@ -97,11 +97,14 @@ void GY521::calibrate(uint16_t times)
     _gze -= getGyroZ();
   }
 
-  //  adjust calibration errors so read() should get all zero's on average.
-  float factor = 1.0 / times;
+  //  scale accelerometer calibration errors so read() should get all zero's on average.
+  float factor = _raw2g / times;
   axe = _axe * factor;
   aye = _aye * factor;
   aze = _aze * factor;
+
+  //  scale gyro calibration errors so read() should get all zero's on average.
+  factor = _raw2dps / times;
   gxe = _gxe * factor;
   gye = _gye * factor;
   gze = _gze * factor;

--- a/GY521.h
+++ b/GY521.h
@@ -33,6 +33,7 @@ const float GRAVITY = 9.80655;
 
 //  CONVERSION CONSTANTS
 #define GY521_RAD2DEGREES          (180.0 / PI)
+#define GY521_DEGREES2RAD          (PI / 180.0)
 #define GY521_RAW2DPS              (1.0 / 131.0)
 #define GY521_RAW2G                (1.0 / 16384.0)
 
@@ -51,7 +52,7 @@ public:
   //  EXPERIMENTAL
   //  calibrate needs to be called to compensate for errors.
   //  must be called after setAccelSensitivity(as); and setGyroSensitivity(gs);
-  void     calibrate(uint16_t times);
+  void     calibrate(uint16_t times, float angleX = 0, float angleY = 0, bool inverted = false);
 
   bool     wakeup();
   //  throttle to force delay between reads.


### PR DESCRIPTION
This adds orientation arguments to the calibrate function, as discussed in #58 

I've had to add an additional bool `inverted`, to tell it, that the MPU is upside down. This keeps it compatible to the `getAngleX` and `getAngleY` which only report in a +/-90° range. 
Alternatively the user can add 180° themselve to the X/Y argument of calibrate and ignore `inverted`.